### PR TITLE
202002496-박상우

### DIFF
--- a/src/main/java/cnu/mvc/domain/member/Member.java
+++ b/src/main/java/cnu/mvc/domain/member/Member.java
@@ -1,5 +1,6 @@
 package cnu.mvc.domain.member;
 
+import java.beans.ConstructorProperties;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -11,7 +12,8 @@ public class Member {
     private String email;
     private String phoneNumber;
     private String pwd;
-
+    // 데이터가 넘어왔을 때 생성자에 대해서 매핑을 하지 못하는 오류가 발생하여 아래의 어노테이션을 작성했습니다.
+    @ConstructorProperties({"email", "name", "pwd", "role"})
     public Member(String name, String email, String phoneNumber, String pwd) {
         this.name = name;
         this.email = email;

--- a/src/main/java/cnu/mvc/domain/member/MemberRepository.java
+++ b/src/main/java/cnu/mvc/domain/member/MemberRepository.java
@@ -22,6 +22,12 @@ public class MemberRepository {
 
     // 구현
     public Member findByEmail(String email) {
+        for(Long id : store.keySet()){
+            Member nowMember = store.get(id);
+            if(nowMember.getEmail().equals(email)){
+                return nowMember;
+            }
+        }
         return null;
     }
 }

--- a/src/main/java/cnu/mvc/domain/member/MemberService.java
+++ b/src/main/java/cnu/mvc/domain/member/MemberService.java
@@ -10,11 +10,25 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     public Member join(Member member){
+        // 들어온 멤버의 email을 가져옵니다.
+        String joinEmail = member.getEmail();
+        // 만약 member를 가져와 null이 아니라면 이미 존재하는 이메일 이므로
+        // IllegalArgumentException을 발생합니다.
+        if (findByEmail(joinEmail) != null) {
+            throw new IllegalArgumentException("이미 존재하는 이메일 계정입니다.");
+        }
+        // null인경우 member가 존재하지 않으므로
         return memberRepository.save(member);
     }
 
     public Member validateMember(String email, String pwd) {
-        Member findMember = findById(1L);
+        Member findMember;
+        // 입력받은 email로 member를 찾습니다.
+        // 들어온 email로 멤버를 찾아 ()을 통해 우선순위를 높여 finMember에 저장을 합니다.
+        // 그후에 null또는 pwd가 다르다면 오류를 발생합니다.
+        if ((findMember = memberRepository.findByEmail(email)) == null || !findMember.getPwd().equals(pwd)) {
+            throw new IllegalArgumentException("이메일 또는 비밀번호를 확인해주세요.");
+        }
         return findMember;
     }
 
@@ -23,6 +37,7 @@ public class MemberService {
     }
 
     // 구현
+    // 이미 memberRepository에서 구현했으므로 따로 건들지 않았습니다.
     public Member findByEmail(String email) {
         return memberRepository.findByEmail(email);
     }


### PR DESCRIPTION
 - 데이터가 넘어왔을 때 생성자에 대해서 매핑을 하지 못하는 오류가 발생하여 아래의 어노테이션을 작성했습니다.
 - 기본생성자가 없어 발생하는 오류를 아래 어노테이션으로 해결했습니다.
    @ConstructorProperties({"email", "name", "pwd", "role"})

아래는 따로 주석을 작성하지 못해 추가했습니다.

Map의 모든 key를 id로 가져와 모든 member에 대해서 email이 같은지 검증합니다.
```java
    // 구현
    public Member findByEmail(String email) {
        for(Long id : store.keySet()){
            Member nowMember = store.get(id);
            if(nowMember.getEmail().equals(email)){
                return nowMember;
            }
        }
        return null;
    }
```